### PR TITLE
Fix spelling mistakes around probability

### DIFF
--- a/dist/components/probability-chart.js
+++ b/dist/components/probability-chart.js
@@ -112,8 +112,8 @@ var ProbabilityChart = (function () {
         }
         this._rawChartData.push(newChartData);
         var minValue = 0;
-        if (this._plottype === 'CP'){minValue=1};  // Cummulative Propability
-        if (this._plottype === 'PC'){minValue=1}; // Propability chart
+        if (this._plottype === 'CP'){minValue=1};  // Cumulative Probability
+        if (this._plottype === 'PC'){minValue=1}; // Probability chart
         var maxValue = this._chartMaxDamage;
         for (var v in newChartData) {
             maxValue = Math.max(maxValue, Number(v));
@@ -128,7 +128,7 @@ var ProbabilityChart = (function () {
         var cumulativeProb = 0;
         for (var i = maxValue; i >= minValue; i--) {
             if (this._plottype === 'CP') {
-            // For cummulative Probs
+            // For cumulative Probs
             cumulativeProb += (newChartData[i] === undefined) ? 0 : newChartData[i];
             }
             else{

--- a/dist/pages/attribute-test.js
+++ b/dist/pages/attribute-test.js
@@ -50,7 +50,7 @@ var AttributeTest = (function () {
         possibleRolls.applyAllRolls(this.diceCount);
         //possibleRolls.showProb();
         var shields = possibleRolls.getAttributeResults(this.Value_to_Test);
-        // I need to transform the shields rolled into sucess propabilities and display these
+        // I need to transform the shields rolled into success probabilities and display these
         this.probabilityChart.selectPlotType('PC')
         this.probabilityChart.addChartData(shields); // Does this work without argument?
 

--- a/dist/pages/info.html
+++ b/dist/pages/info.html
@@ -8,14 +8,14 @@
 
                 <p><b>Descent Damage Calculator V1.2</b></p>
 
-                <p>Calculates Propabilities to deal damage, roll defence, roll surges and to pass attribute tests.</p>
+                <p>Calculates Probabilities to deal damage, roll defence, roll surges and to pass attribute tests.</p>
 
 
                 <p>Two plots can be drawn:</p>
-                <p>1. Absolute Propabilitiy:<br>
-                This is the propability to deal exactly X amount of damage(roll shields/surges etc.)</p>
-                <p>2. Cummulative propability:<br>
-                This is the propability to deal at least x amount of damage(roll shields/surges etc.)</p>
+                <p>1. Absolute Probabilitiy:<br>
+                This is the probability to deal exactly X amount of damage(roll shields/surges etc.)</p>
+                <p>2. Cummulative probability:<br>
+                This is the probability to deal at least x amount of damage(roll shields/surges etc.)</p>
 
 
                 <p>For the rerolls and set dice, I had to make a few assumptions, lest the program would be quite a bit more complicated.<br>
@@ -26,7 +26,7 @@
                   green: 1 damage<br>
                   brown/grey/black: blank<br>
                 2. For the set dice I am assuming that an ability lets you set the dice if you roll X or blanks or otherwise the worst face. Hence, the worst result is replaced with the best one.<br>
-                3. Mark the fact that range is not taken into account for these considerations. Hence, the displayed damage propabilities for long-range attacks would be higher than displayed as X is replaced by the face with range 2.
+                3. Mark the fact that range is not taken into account for these considerations. Hence, the displayed damage probabilities for long-range attacks would be higher than displayed as X is replaced by the face with range 2.
                 </p>
 
             </span>

--- a/dist/util/PossibleRolls.js
+++ b/dist/util/PossibleRolls.js
@@ -267,7 +267,7 @@ var PossibleRolls = (function () {
             //console.log("maxDamage: %d", maxDamage);
             this.updateValue(effectiveDamage, maxDamage, calcDamageResult.probability);
         }
-        return effectiveDamage;  // Does NOT return actual damage, but propabilities to deal damage!
+        return effectiveDamage;  // Does NOT return actual damage, but probabilities to deal damage!
     };
 
     // Deflected Damage
@@ -282,7 +282,7 @@ var PossibleRolls = (function () {
             //console.log("maxDamage: %d", maxDefence);                                    // updateValue(dict, key, value)
             this.updateValue(deflectedDamage, maxDefence, calcDefenceResult.probability);  // really update the probability?
             }
-        return deflectedDamage; // Does NOT return actual number of shields, but propabilities to get shields!
+        return deflectedDamage; // Does NOT return actual number of shields, but probabilities to get shields!
     };
 
     ////////////////////////////////////////////////////////////////////////////
@@ -322,7 +322,7 @@ var PossibleRolls = (function () {
             counter++;
             }
 
-        return AttributeSuccess; // Does NOT return actual number of shields, but propabilities to get shields!
+        return AttributeSuccess; // Does NOT return actual number of shields, but probabilities to get shields!
 
 
     };


### PR DESCRIPTION
While looking at the site I noticed that probability was spelled incorrectly on the info page.

This fixes those and other instances of it.

Note: My assumption is that the dist directory shouldn't actually be updated, but I didn't see where these were getting populate from any source files.